### PR TITLE
add include_path to clang_arg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -296,7 +296,8 @@ fn generate_bindings(out_dir: &Path, include_path: &Path) {
         .derive_copy(true)
         .derive_eq(true)
         .derive_ord(true)
-        .impl_debug(true);
+        .impl_debug(true)
+        .clang_args(&["-I", &path_to_str(include_path)]);
 
     // Do not expose deprecated functions.
     for &blacklisted_function in &[


### PR DESCRIPTION
Without this change, buildgen was not using the path provided with SELINUX_INCLUDE_DIR to search for selinux.h